### PR TITLE
Summary: Enforced unique pantry/recipes per authenticated user.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "homeslice",
       "version": "0.0.0",
       "dependencies": {
-        "firebase": "^11.7.1",
+        "firebase": "^11.7.3",
         "react": "^19.1.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -901,15 +901,14 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.13",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.13.tgz",
-      "integrity": "sha512-X+6wMOPgA9l0AeeMdMcMfaCP4XKPvrhx55MGuMrfHvUrOvFKldpzBum7KkoGJMoexKmqmKP+mCmJMY9Fb8K6Hw==",
-      "license": "Apache-2.0",
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.15.tgz",
+      "integrity": "sha512-LzRzWtD1t1Fdzts+mHP6TEcIVlPK7XifZWMwM3+0RQbZCD4PxkB1myAvkbWVlXXzD6DlGS5Wc7kpt0oFDL/XxA==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/installations": "0.6.14",
+        "@firebase/component": "0.6.16",
+        "@firebase/installations": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -917,15 +916,14 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.19.tgz",
-      "integrity": "sha512-l/PYILG9Tu4D5XtazqzvT5J6f7B/laqlaoSjiee6QdQkEg1kmMIeAaLKWGbf8tR/T3g6Lv3lx1AwJBuLhVaqTQ==",
-      "license": "Apache-2.0",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.21.tgz",
+      "integrity": "sha512-t/uNh8rXws3t8nRdH75GclPP7/QCWDnVv78NfHMnedjbuQg6aF7YNbpHNznIJiKVKkRkcQobtpBqGdIPdvf3ZA==",
       "dependencies": {
-        "@firebase/analytics": "0.10.13",
+        "@firebase/analytics": "0.10.15",
         "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.6.14",
-        "@firebase/util": "1.11.1",
+        "@firebase/component": "0.6.16",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -935,18 +933,16 @@
     "node_modules/@firebase/analytics-types": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.12.1.tgz",
-      "integrity": "sha512-ASExOlmmjRMdwOQ65Oj6R9JBqa7iiT1/LgZjtbU7FqxoJZNWHrt39NJ/z2bjyYDdAHX8jkY7muFqzahScCXgfA==",
-      "license": "Apache-2.0",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.12.3.tgz",
+      "integrity": "sha512-8BbBlBUEZ9LUQ1Sm9wcDNv+gdj+3k3hv2I59dsw0tayjdmJTo+IDWsWe1N7sUSi20Hc7p3QoE9DdVxp4jtT7Mg==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -955,14 +951,13 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.9.1.tgz",
-      "integrity": "sha512-3gt4yt7oFXalJ2pLpawxKZI9lLLv2Jo2H3AoVKv9Fqy6zQmAC0nSItt9JUl2iDNd11V/bj4OC5rfoAjtyK22dQ==",
-      "license": "Apache-2.0",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.9.3.tgz",
+      "integrity": "sha512-jACDmeq5jEazWOojVr5lWwEe70slJfeCszsKL3TVyxGHMnXVBH5tJQme2DuMqhyZv36SVhh0zt6i3dB+lwhf7w==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -973,16 +968,15 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.22.tgz",
-      "integrity": "sha512-Tag7kI0vnzlsKrpnnhUgbTTTv2NNGR+Sf2pHiy3QApOaOG5tx6W5OQyvKv3+KaGbjEU19mvgOzOe1q5XHDoRvQ==",
-      "license": "Apache-2.0",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.24.tgz",
+      "integrity": "sha512-hLLFxyurZ+HzAuSMHQufyCq4Cy7KNwtzXcqzs/+eTsQ+gkyGFS+eavcjzwxg9qwSQPqMkXE9otGenvMsWmBbQQ==",
       "dependencies": {
-        "@firebase/app-check": "0.9.1",
+        "@firebase/app-check": "0.9.3",
         "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -995,25 +989,22 @@
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A=="
     },
     "node_modules/@firebase/app-check-types": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.3.1.tgz",
-      "integrity": "sha512-NCW2H/FawF0cBs3ciRx7NLt0H/VKn71H/q1RfTfctFez7maZ3KJi8QudpmIwoEqEW1N5HiXWxKAHY18Uo6o2Bg==",
-      "license": "Apache-2.0",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.3.3.tgz",
+      "integrity": "sha512-olkQJHeU7t0MQJQ3wSgZFkg34lR2vUoAS7B5+2y7AheZ/mCNazwm3TjfzMfPoy9CB1WhwTOhizBQdDnChSsAXA==",
       "dependencies": {
-        "@firebase/app": "0.12.1",
-        "@firebase/component": "0.6.14",
+        "@firebase/app": "0.12.3",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1023,18 +1014,16 @@
     "node_modules/@firebase/app-types": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw=="
     },
     "node_modules/@firebase/auth": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.2.tgz",
-      "integrity": "sha512-HHudcj3CJyXpoMKslNOVHGSNJdAUjvy5xBA/G/uPb32QFqvx5F3EW9RDYvve2IHEN7Vpc1QTkk/28J32x83UGA==",
-      "license": "Apache-2.0",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.4.tgz",
+      "integrity": "sha512-rZQZQkn5x7BcHenYJi9RYWoOMJHdM/CsF6DMclb/CKbntzjUaZj+R45Iyzf/BFUJ9L2sA4bNPhJK9x+l9VKvLQ==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1051,15 +1040,14 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.22",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.22.tgz",
-      "integrity": "sha512-RC7QdBIgg/hyxhJW2sso9Syb9iSr2wZ+vB6c/PnN+64uNZhp8bdxauhmDJGmbvStwCf/l2RpBsusVXQXVMnrgQ==",
-      "license": "Apache-2.0",
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.24.tgz",
+      "integrity": "sha512-nRGfAqK9EMoYcSdVJMWuhNJNFqTi5qU+O4U//vGjB9mKfX4v+eDYAxCf5eyB+2vxTOP55xR28AtA6He4LQKNJA==",
       "dependencies": {
-        "@firebase/auth": "1.10.2",
+        "@firebase/auth": "1.10.4",
         "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.6.14",
-        "@firebase/util": "1.11.1",
+        "@firebase/component": "0.6.16",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1072,26 +1060,23 @@
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA=="
     },
     "node_modules/@firebase/auth-types": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
       "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.14.tgz",
-      "integrity": "sha512-kf/zAT8GQJ9nYoHuj0mv7twp1QzifKYrO+GsmsVHHM+Hi9KkmI7E3B3J0CtihHpb34vinl4gbJrYJ2p2wfvc9A==",
-      "license": "Apache-2.0",
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.16.tgz",
+      "integrity": "sha512-whx+e3pgC3J9O6t4LOB8jiLk3tpWtnXaQ+xt/ys/4IGUPRI+nnWooVdtWrEnMga/gT03ug9SdEAEJLl6I1BIlg==",
       "dependencies": {
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1099,15 +1084,14 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.5.tgz",
-      "integrity": "sha512-YtiSRdiJicaXuyRC/yJjErQ/aHIlWt2umcBSpggYCP9TqKRIsJtgoskSSGzWJhzHn13BojYa7rWXmutTc5tovg==",
-      "license": "Apache-2.0",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.7.tgz",
+      "integrity": "sha512-AvOXRsVDF8krA9lgXfj+v4cj5/L9u/2OIaR/JZ5cTf5QAcvPUExsB7gX0uvJFh9wNlv1E51TDVihcMlXYH1NiA==",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1115,16 +1099,15 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.15.tgz",
-      "integrity": "sha512-xmeTqKoIB2u1AXvLc1jq3Val0QAHUr49YycAr6feoDD7zM9dCjSk8rq9s1ESTv+tbbqS2BRoTpjIvxwXRTKhQQ==",
-      "license": "Apache-2.0",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.17.tgz",
+      "integrity": "sha512-CUUsegGubS90/QkZ4sO84SgoJlnYOCaArVl6CG8aTSuTJoEAoD8elVwR02aPM80m0GOFM6NBT7B+ayK7jeVmMA==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -1133,16 +1116,15 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.6.tgz",
-      "integrity": "sha512-vv15b1E59sLwoVdjGKvJ75ok9Qu1VRJC/7KXAQGnXvURAL199Ndy1YEw6/GA9twoFlLCYnd2ltxxB2pPiL1Vqw==",
-      "license": "Apache-2.0",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.8.tgz",
+      "integrity": "sha512-GsopZGu8SefAUHtdh+1HL10TcpuBmXCz7RRJ1iPP9sbkF0vWHu5eYpkqKzaZ687EyS0SG03o2rno7JIwm1hbYQ==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/database": "1.0.15",
-        "@firebase/database-types": "1.0.11",
+        "@firebase/component": "0.6.16",
+        "@firebase/database": "1.0.17",
+        "@firebase/database-types": "1.0.13",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1150,24 +1132,22 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.11.tgz",
-      "integrity": "sha512-LBZG/nT6GbntbIdGxBNvu9PBtj4xUEE9wX8AFF6njFK/MufYBESiKqT+jhDwmbcM4zAha9U0Pcca8FvJ1z1bYw==",
-      "license": "Apache-2.0",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.13.tgz",
+      "integrity": "sha512-HoMVmHNLNEmSe55XMKXYbfAaie21h++G7gxhIttj330yPlW+RgG00CLedpmQvaqfEHEvh+6eUjddtJ/ezm1x2w==",
       "dependencies": {
         "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.11.1"
+        "@firebase/util": "1.11.3"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.7.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.12.tgz",
-      "integrity": "sha512-50KRdSp8xA7+G0wfWxlnCoEN951mt8BVdLMxeP57Rehj2DqIb41q6Fc6JH0dfQ4TlMqWua1YfVY1jPEAaHVF9w==",
-      "license": "Apache-2.0",
+      "version": "4.7.14",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.14.tgz",
+      "integrity": "sha512-YLz71p96ACfILNjnqh7H6ilsT3AZZyDpCCE+wpl8mJklAbdpyd2ahNIqS1eBCjseqls8vQO/XTaIcbpkSgQFIg==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "@firebase/webchannel-wrapper": "1.0.3",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
@@ -1181,15 +1161,14 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.47",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.47.tgz",
-      "integrity": "sha512-8fs4Zz2nXOgOf62wCK06Fo6uMGojyEhNEg/x2Pdnir9H9AH4T5T5q4/0MXdgPFSNBFcrPl+SVlmD1WTEZL+XGA==",
-      "license": "Apache-2.0",
+      "version": "0.3.49",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.49.tgz",
+      "integrity": "sha512-5sj+GFTV+GxVBOhsiRitIrZ0dPIIudllGvJxjfikcnUZV0wq6urmjjWSrmp8V3syc6QLEnGhGSWoArDTnHce1g==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/firestore": "4.7.12",
+        "@firebase/component": "0.6.16",
+        "@firebase/firestore": "4.7.14",
         "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1203,23 +1182,21 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
       "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.4.tgz",
-      "integrity": "sha512-XAvDHvJ1222+9lPHssgRzALejCSW/CN+mlyLbLXHSJHujfIfn9yPHOcAj9KfACavd+F8ey7h4mpxfHowczpVXw==",
-      "license": "Apache-2.0",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.6.tgz",
+      "integrity": "sha512-HfLWbphl5sA/+4wjwHWPHHgvuTDN+4DIs3bxW1746nMAblCQ3b26yHDssRCCZkpgzO1o01j/cmu1dbRL9pSJfg==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1230,15 +1207,14 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.21.tgz",
-      "integrity": "sha512-FFtdZt6ve6VxOW6Y6IytR5wXXRQ0/IXTXsztrPd9HhilzzbHbXKYyyvODrnHfraslTW50gdZlj7WlZieiVhcig==",
-      "license": "Apache-2.0",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.23.tgz",
+      "integrity": "sha512-yt7Odu1gwPYE6B7C/rRcXZH8QlXOpqdu20ddCvp4H2sI3Le37OCxRxpecDNR0sUjtDmCeEFTlB2VV9RT8CENxQ==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/functions": "0.12.4",
+        "@firebase/component": "0.6.16",
+        "@firebase/functions": "0.12.6",
         "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1251,17 +1227,15 @@
     "node_modules/@firebase/functions-types": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg=="
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.14.tgz",
-      "integrity": "sha512-uE837g9+sv6PfjWPgOfG3JtjZ+hJ7KBHO4UVenVsvhzgOxFkvLjO/bgE7fyvsaD3fOHSXunx3adRIg4eUEMPyA==",
-      "license": "Apache-2.0",
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.16.tgz",
+      "integrity": "sha512-8oE25Nkdf/xUazViCYkEbvt42PXZ2TcnDuXUFykPCJ88xGEjtt9t+oCv2UpW9j1XEq3v80hlyX7iwWXE5RWj3w==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/util": "1.11.1",
+        "@firebase/component": "0.6.16",
+        "@firebase/util": "1.11.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1270,15 +1244,14 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.14.tgz",
-      "integrity": "sha512-6+xTtM2WwnVWY2qO8seWZqkrwhklFsgDCzmburqppHrGXW7Saxpyb+EqSHjFRcQleq5UGFwo0xqorLCwHa9WXA==",
-      "license": "Apache-2.0",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.16.tgz",
+      "integrity": "sha512-gL5p1t4OzhAtqlc6t1kX7IKIEwF0D62/1+GmN8RK2enlnxGZ+whPFeTHfDM7IMxoMkdJ6o8/3X5Z7E2Hkha1Hw==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/installations": "0.6.14",
+        "@firebase/component": "0.6.16",
+        "@firebase/installations": "0.6.16",
         "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1289,7 +1262,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
       "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
@@ -1298,7 +1270,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
       "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1307,15 +1278,14 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.18",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.18.tgz",
-      "integrity": "sha512-2MGhUGoCZloB7ysoYzG/T2nnRmHYLT+AcqYouZuD6APabpkDhF8lHsmSQq4MFSlXhI3DKFOXxjuvbY8ec4C2JQ==",
-      "license": "Apache-2.0",
+      "version": "0.12.20",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.20.tgz",
+      "integrity": "sha512-YkUPUlfrsBQ0uOo2AxL2pGN9Ns1WmL2ohzTqJVGXNyne6YBc8ppFtxCQqB4qL5hRdgh3/ZJmnrOm2Yee/SfIgA==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/installations": "0.6.14",
+        "@firebase/component": "0.6.16",
+        "@firebase/installations": "0.6.16",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1324,14 +1294,13 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.18.tgz",
-      "integrity": "sha512-Msrm6krO0SNqJak5cLK1IuNYmQgWwofE/o2Zz/k1Ckb9qZTMjfmKkjWq7II9se+BFsPAe3YH+05Kx2RldwYYGw==",
-      "license": "Apache-2.0",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.20.tgz",
+      "integrity": "sha512-AQtNqofrZTbNX4h8eXtFyIhhJm5MiavPjXU7vk4yG1fJRCxaVEiWuj/lBQdDbKnA0E9Mv8wE1N6eWC1pjOnZfA==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/messaging": "0.12.18",
-        "@firebase/util": "1.11.1",
+        "@firebase/component": "0.6.16",
+        "@firebase/messaging": "0.12.20",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1341,19 +1310,17 @@
     "node_modules/@firebase/messaging-interop-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q=="
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.3.tgz",
-      "integrity": "sha512-PNBBbMskmSK8D8S1uZRzTqC2LpPDxVw/RbM5IsfrzyyJcyT6Lo+L8Y1vjBvVuK2Mw6pS6M6TgGncf2s+wq3kRA==",
-      "license": "Apache-2.0",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.5.tgz",
+      "integrity": "sha512-1bwG4ACRQZX6fKcIobZaSsCe9eRZnSKHTJ3/4GNhS7rO2W9nlj30xRd0GozZszBLgjn6lFcFPRxV+o2mcgjmOA==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/installations": "0.6.14",
+        "@firebase/component": "0.6.16",
+        "@firebase/installations": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -1362,16 +1329,15 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.16.tgz",
-      "integrity": "sha512-B0Wv11TnS4leQmkCHDx/quyy3B6Qz+Zog0y/um2dSlfwO8YnbfJYqG+zUlJsCs/dB8dnyNbcP0o80cZq6y8UyQ==",
-      "license": "Apache-2.0",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.18.tgz",
+      "integrity": "sha512-gwgENv/KnIa/EVErFC1MaM+r/Qs9lM/XAhI1x1/gwd56B9kYA77x1L0DggElb24ddm3Vo83tQVnV2N6nLeIjyQ==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/performance": "0.7.3",
+        "@firebase/performance": "0.7.5",
         "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1381,19 +1347,17 @@
     "node_modules/@firebase/performance-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ=="
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.1.tgz",
-      "integrity": "sha512-nlZ75rEVuGFGjUHuQuZIeLTTyHgCjW4jD2uCXu6mwNrQ6Mh18gjN3rS0Pfxz40NYcNlzfWPf0uvA4CYMXWa6yA==",
-      "license": "Apache-2.0",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.3.tgz",
+      "integrity": "sha512-Bhf8KB1EGwo6exaN7XcOnkzgkmjBJkAk4+Ny+dBDW1+AI+KIrZ9ToCmP1MpSJTNJ4ZBbLWruawEse7cOJzIe4w==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/installations": "0.6.14",
+        "@firebase/component": "0.6.16",
+        "@firebase/installations": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1401,16 +1365,15 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.14.tgz",
-      "integrity": "sha512-qr0H1+y58ErLRbvD58IzlyVK+DjtGCNRDq0E1EM6xj5K3rB+3Ifmwq1EU5gzX0kI+xQlXYNHMFYxd+PTgwblUg==",
-      "license": "Apache-2.0",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.16.tgz",
+      "integrity": "sha512-In4cP+PxPWXF09FJLQs22Yx2x99AYO6u1egxpECPhCulGnLj+B8vhuqgV3aFJEoZ+4vjg+u0FY3+kzeXeNFf/Q==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/remote-config": "0.6.1",
+        "@firebase/remote-config": "0.6.3",
         "@firebase/remote-config-types": "0.4.0",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1420,17 +1383,15 @@
     "node_modules/@firebase/remote-config-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
-      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.8.tgz",
-      "integrity": "sha512-DjO8bSbwY/o+dbri3wear1gkrorgTpqi4uBTMoZZ02WOVR1A5AX8k/eYpUVuAvWyEDMWz/ECv4PgEokNajDsow==",
-      "license": "Apache-2.0",
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.10.tgz",
+      "integrity": "sha512-OEt3jD5O3Xp8PJrMTRw0WCUvTkrc3ENzY8RMN5OUIWX/oIKxv+kV0WyNjTYu3s4HsQs0Q9rjMPbREMIihM0KDg==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/util": "1.11.1",
+        "@firebase/component": "0.6.16",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1441,15 +1402,14 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.18.tgz",
-      "integrity": "sha512-2A4LoqVV4GG8YlLU07ktjw8Xl558odeTg9a24wnT4P8Syf17Q6TjYCTwYGaFxYjQ00V7HUh9TfJIg9uO5zjeJw==",
-      "license": "Apache-2.0",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.20.tgz",
+      "integrity": "sha512-JjXcyyjlPbZ3SCBwDfjk1hVfc3ybuezO0LvvmHEr6gGnZkUaM/iOjgSdQ9xXcRAWL5IGEby0qlDCAF3TClTtGQ==",
       "dependencies": {
-        "@firebase/component": "0.6.14",
-        "@firebase/storage": "0.13.8",
+        "@firebase/component": "0.6.16",
+        "@firebase/storage": "0.13.10",
         "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1463,18 +1423,16 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
       "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.11.1.tgz",
-      "integrity": "sha512-RXg4WE8C2LUrvoV/TMGRTu223zZf9Dq9MR8yHZio9nF9TpLnpCPURw9VWWB2WATDl6HfIdWfl2x2SJYtHkN4hw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.11.3.tgz",
+      "integrity": "sha512-4wYnOV9FpwdCq3rHQOCrdx4AQBUbfH1p2DhWGQxlQ+D3Xl/wSxc/HttcyPN4NNFiynxoNCFGWQH/zdhRfxP1Zg==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1483,15 +1441,14 @@
       }
     },
     "node_modules/@firebase/vertexai": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/vertexai/-/vertexai-1.2.2.tgz",
-      "integrity": "sha512-DtHkD24fkewl88MRYlAdvyo1yXg2AQMa/3u+eW47EKKifKoVfDSyN9HVCP51saqzlRmDaeVuS1i2CY3Tu16lgQ==",
-      "license": "Apache-2.0",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai/-/vertexai-1.2.4.tgz",
+      "integrity": "sha512-QvNp8mqD/TmAfdSu5lBwqDarAmW7l6j2fRC/S9GwvsE9l/oz+HH+glkQ/qn8+Qd/mjD3OGYLWQFYhD8bF9t5Vg==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.6.14",
+        "@firebase/component": "0.6.16",
         "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.11.1",
+        "@firebase/util": "1.11.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1505,14 +1462,12 @@
     "node_modules/@firebase/webchannel-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
-      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ=="
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
       "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -1525,7 +1480,6 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1699,32 +1653,27 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1733,32 +1682,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.0",
@@ -2411,7 +2355,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2554,7 +2497,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2662,8 +2604,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/esbuild": {
       "version": "0.25.2",
@@ -2971,7 +2912,6 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
       "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "license": "Apache-2.0",
       "dependencies": {
         "websocket-driver": ">=0.5.1"
       },
@@ -3023,39 +2963,38 @@
       }
     },
     "node_modules/firebase": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.7.1.tgz",
-      "integrity": "sha512-Jr0uKRwHAtnlyHis9+48mo3aXeChekaxhy6kSaqBC44qdogwAlTWiY3OTqmRomGA8B62rqS3LwpNyAEZsrhf7w==",
-      "license": "Apache-2.0",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.7.3.tgz",
+      "integrity": "sha512-5zhITZvxl6BQbf7RQNA6h08mCMUkSnJtgMzm67JFbXo2zfgWDMuakQOIlHAtnJBc/f3llvB3yoH2v1Nr2/bMMQ==",
       "dependencies": {
-        "@firebase/analytics": "0.10.13",
-        "@firebase/analytics-compat": "0.2.19",
-        "@firebase/app": "0.12.1",
-        "@firebase/app-check": "0.9.1",
-        "@firebase/app-check-compat": "0.3.22",
-        "@firebase/app-compat": "0.3.1",
+        "@firebase/analytics": "0.10.15",
+        "@firebase/analytics-compat": "0.2.21",
+        "@firebase/app": "0.12.3",
+        "@firebase/app-check": "0.9.3",
+        "@firebase/app-check-compat": "0.3.24",
+        "@firebase/app-compat": "0.3.3",
         "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.2",
-        "@firebase/auth-compat": "0.5.22",
-        "@firebase/data-connect": "0.3.5",
-        "@firebase/database": "1.0.15",
-        "@firebase/database-compat": "2.0.6",
-        "@firebase/firestore": "4.7.12",
-        "@firebase/firestore-compat": "0.3.47",
-        "@firebase/functions": "0.12.4",
-        "@firebase/functions-compat": "0.3.21",
-        "@firebase/installations": "0.6.14",
-        "@firebase/installations-compat": "0.2.14",
-        "@firebase/messaging": "0.12.18",
-        "@firebase/messaging-compat": "0.2.18",
-        "@firebase/performance": "0.7.3",
-        "@firebase/performance-compat": "0.2.16",
-        "@firebase/remote-config": "0.6.1",
-        "@firebase/remote-config-compat": "0.2.14",
-        "@firebase/storage": "0.13.8",
-        "@firebase/storage-compat": "0.3.18",
-        "@firebase/util": "1.11.1",
-        "@firebase/vertexai": "1.2.2"
+        "@firebase/auth": "1.10.4",
+        "@firebase/auth-compat": "0.5.24",
+        "@firebase/data-connect": "0.3.7",
+        "@firebase/database": "1.0.17",
+        "@firebase/database-compat": "2.0.8",
+        "@firebase/firestore": "4.7.14",
+        "@firebase/firestore-compat": "0.3.49",
+        "@firebase/functions": "0.12.6",
+        "@firebase/functions-compat": "0.3.23",
+        "@firebase/installations": "0.6.16",
+        "@firebase/installations-compat": "0.2.16",
+        "@firebase/messaging": "0.12.20",
+        "@firebase/messaging-compat": "0.2.20",
+        "@firebase/performance": "0.7.5",
+        "@firebase/performance-compat": "0.2.18",
+        "@firebase/remote-config": "0.6.3",
+        "@firebase/remote-config-compat": "0.2.16",
+        "@firebase/storage": "0.13.10",
+        "@firebase/storage-compat": "0.3.20",
+        "@firebase/util": "1.11.3",
+        "@firebase/vertexai": "1.2.4"
       }
     },
     "node_modules/flat-cache": {
@@ -3108,7 +3047,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3159,14 +3097,12 @@
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "license": "MIT"
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
     },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "license": "ISC"
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3219,7 +3155,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3364,8 +3299,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3377,8 +3311,7 @@
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3610,11 +3543,10 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
-      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
+      "integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3747,7 +3679,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3854,8 +3785,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -3916,7 +3846,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3930,7 +3859,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4038,8 +3966,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
@@ -4250,14 +4177,12 @@
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
       "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -4271,7 +4196,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4306,7 +4230,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4323,7 +4246,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -4339,7 +4261,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4357,7 +4278,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "firebase": "^11.7.1",
+    "firebase": "^11.7.3",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/client/src/pages/RecipesPage.tsx
+++ b/client/src/pages/RecipesPage.tsx
@@ -1,11 +1,121 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import EditIcon from '../components/icons/EditIcon';
+import TrashIcon from '../components/icons/TrashIcon';
+import { useAuth } from '../context/AuthContext';
+import '../styles/RecipesPage.css';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+interface Recipe {
+  id: string;
+  title: string;
+  description?: string;
+  ingredients: string[];
+  steps: string[];
+  prep_time: number;
+  cook_time: number;
+  servings: number;
+  image_url: string | null;
+}
 
 export default function RecipesPage() {
+  const { token } = useAuth();    // Firebase ID token
+  const navigate = useNavigate();
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch current user's save recipes
+  useEffect(() => {
+    const fetchRecipes = async () => {
+      try {
+        const res = await fetch(`${API_URL}/recipes`, {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type':  'application/json',
+          },
+        });
+        if (!res.ok) {
+          throw new Error(`Server responded ${res.status}`);
+        }
+        const data: Recipe[] = await res.json();
+        setRecipes(data);
+      } catch (err: any) {
+        setError(err.message || 'Could not load recipes');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecipes();
+  }, [token]);
+
+  // Navigate to individual recipe page
+  const handleView = (id: string) => {
+    navigate(`/recipe/${id}`);
+  };
+
+  // Delete recipe on server and remove from local state
+  const handleDelete = async (id: string) => {
+    if (!token) return;
+    try {
+      const res = await fetch(`${API_URL}/recipes/${id}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+      setRecipes((prev) => prev.filter((r) => r.id !== id));
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete recipe');
+    }
+  };
+
+  // Render loading or error states
+  if (loading) return <p>Loading recipes…</p>;
+  if (error)   return <p className="error">{error}</p>;
+
   return (
     <div className="recipes-page">
-      <h1>#TODO</h1>
-      <p>Add recipes from database connection</p>
-      <p>Styling CSS</p>
+      <h1>Your Recipes</h1>
+
+      {recipes.length === 0 ? (
+        <p>You have no saved recipes.</p>
+      ) : (
+        <div className="recipe-list">
+          {recipes.map((r) => (
+            <div key={r.id} className="recipe-card">
+              <span className="recipe-title">{r.title}</span>
+              {r.description && <p className="recipe-desc">{r.description}</p>}
+
+              <div className="recipe-actions">
+                <button
+                  onClick={() => handleView(r.id)}
+                  aria-label="View or edit recipe"
+                  className="icon-button"
+                >
+                  <EditIcon />
+                </button>
+                <button
+                  onClick={() => handleDelete(r.id)}
+                  aria-label="Delete recipe"
+                  className="icon-button"
+                >
+                  <TrashIcon />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+    {/* Generate New Recipe button */}
+    <button
+      className="generate-button"
+      onClick={() => navigate('/recipes/generate')}
+    >
+      Generate New Recipe
+    </button>
     </div>
   );
 }

--- a/client/src/styles/RecipesPage.css
+++ b/client/src/styles/RecipesPage.css
@@ -1,26 +1,137 @@
-.pantry-page {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    background-color: #fdf8f0; 
-    color: #333333; 
-    font-family: 'Montserrat', sans-serif;
-  }
-  
-  .pantry-page h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 16px;
-    text-align: center;
-    color: #000000; 
-  }
-  
-  .pantry-page p {
-    font-size: 1.25rem;
-    font-weight: 400;
-    color: #7a7a7a; 
-    text-align: center;
-    max-width: 600px;
-  }
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Montserrat:wght@400;600&display=swap');
+
+:root {
+  --bg-page:    #fdf8f0;
+  --bg-card:    #ffffff;
+  --text-main:  #333333;
+  --accent:     #b94e48;
+  --muted:      #7a7a7a;
+  --shadow:     rgba(0, 0, 0, 0.1);
+  --font-heading: 'Playfair Display', serif;
+  --font-body:    'Montserrat', sans-serif;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-page);
+  color: var(--text-main);
+  font-family: var(--font-body);
+}
+
+.recipes-page {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg-card);
+  padding: 32px;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px var(--shadow);
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Heading style */
+.recipes-page > h1 {
+  font-family: var(--font-heading);
+  font-size: 2.75rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  letter-spacing: 2px;
+  color: var(--accent);
+}
+
+/* List wrapper for cards */
+.recipe-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+/* Individual recipe card */
+.recipe-card {
+  background: var(--bg-card);
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px var(--shadow);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Title inside the card */
+.recipe-card .recipe-title {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  margin: 0;
+  color: var(--text-main);
+}
+
+/* Optional description - DO WE WANT THIS? */
+.recipe-card .recipe-desc {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* Actions row: view/edit & delete */
+.recipe-card .recipe-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+/* Icon buttons matching pantry style */
+.icon-button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--muted);
+  transition: color 0.2s;
+}
+
+.icon-button:hover {
+  color: var(--accent);
+}
+
+.icon-button svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+}
+
+/* If you have a “Generate New” button below the list */
+.generate-button {
+  width: 100%;
+  padding: 12px;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-family: var(--font-body);
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  transition: background-color 0.3s;
+  cursor: pointer;
+}
+
+.generate-button:hover {
+  background: #55338e;
+}

--- a/server/models/ingredient.py
+++ b/server/models/ingredient.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field
 from bson import ObjectId
 from typing import List
 import os
+from typing import Optional
+from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -26,6 +28,15 @@ class Ingredient(BaseModel):
         description="Quantity must be greater than 0"
     )
 
+# Model for what lives in the database, tied to owner
+class IngredientInDB(Ingredient):
+    id: Optional[str] = Field(alias="_id")
+    user_id: str = Field(..., description="Owner (Firebase) UID")
+
+    # allows reading of _id via alias and populate from Mongo docs
+    class Config:
+        validate_by_name = True
+        from_attributes = True
 
 # Helper to format MongoDB documents
 def format_ingredient(doc) -> dict:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,3 +4,4 @@ motor==3.7.0
 python-dotenv==1.0.0
 email-validator==2.0
 firebase-admin==6.1.0
+pydantic>=2.0

--- a/server/routes/ingredients.py
+++ b/server/routes/ingredients.py
@@ -1,58 +1,57 @@
-import os
-from fastapi import APIRouter, HTTPException
-from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import BaseModel
+from fastapi import APIRouter, HTTPException, Depends, status
+from motor.motor_asyncio import AsyncIOMotorDatabase
 from typing import List
 from bson import ObjectId
-from dotenv import load_dotenv
 
-load_dotenv()
+from models.ingredient import Ingredient, IngredientInDB, format_ingredient
+from db import get_db
+from dependencies import get_current_user   # ensures ingredients operations are scoped to users
 
-MONGO_URI = os.getenv("MONGODB_CONNECT_STRING")
-DB_NAME = os.getenv("MONGO_DB_NAME")
-
-client = AsyncIOMotorClient(MONGO_URI)
-db = client[DB_NAME]
-
-router = APIRouter()
-
-
-class Ingredient(BaseModel):
-    name: str
-    quantity: float
-
-
-def format_ingredient(doc) -> dict:
-    return {
-        "id": str(doc["_id"]),
-        "name": doc["name"],
-        "quantity": doc["quantity"],
-    }
+router = APIRouter(tags=["ingredients"])
 
 
 @router.post("/", response_model=dict)
-async def create_ingredient(ingredient: Ingredient):
+async def create_ingredient(
+    ingredient: Ingredient,
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user)
+):
+    # Create new ingredient owned by authenticated user
     print(f"POST /ingredients - Creating: {ingredient}")
-    result = await db.ingredients.insert_one(ingredient.model_dump())
+    new_doc = ingredient.model_dump()
+    new_doc["user_id"] = current_user["uid"]
+    result = await db.ingredients.insert_one(new_doc)
     created = await db.ingredients.find_one({"_id": result.inserted_id})
     print(f"Created ingredient with ID: {result.inserted_id}")
     return format_ingredient(created)
 
 
 @router.get("/", response_model=List[dict])
-async def get_all_ingredients():
+async def get_all_ingredients(
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    # List ingredients owned by authenticated user
     print("GET /ingredients - Fetching all ingredients")
-    docs = await db.ingredients.find().to_list(100)
+    docs = await db.ingredients.find(
+        {"user_id": current_user["uid"]}
+    ).to_list(100)
     return [format_ingredient(doc) for doc in docs]
 
 
 @router.get("/{ingredient_id}", response_model=dict)
-async def get_ingredient(ingredient_id: str):
+async def get_ingredient(
+    ingredient_id: str,
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    # Fetch a single ingredient by ID, ensuring ownership
     print(f"GET /ingredients/{ingredient_id}")
     try:
-        ingredient = await db.ingredients.find_one(
-            {"_id": ObjectId(ingredient_id)}
-        )
+        ingredient = await db.ingredients.find_one({
+            "_id": ObjectId(ingredient_id),
+            "user_id": current_user["uid"]
+        })
     except Exception:
         raise HTTPException(400, detail="Invalid ID format")
     if not ingredient:
@@ -61,29 +60,48 @@ async def get_ingredient(ingredient_id: str):
 
 
 @router.put("/{ingredient_id}", response_model=dict)
-async def update_ingredient(ingredient_id: str, updated: Ingredient):
+async def update_ingredient(
+    ingredient_id: str,
+    updated: Ingredient,
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    # Edit an ingredient document if owned by current user
     print(f"PUT /ingredients/{ingredient_id} - New data: {updated}")
     try:
-        result = await db.ingredients.replace_one(
-            {"_id": ObjectId(ingredient_id)}, updated.model_dump()
+        result = await db.ingredients.update_one(
+            {
+                "_id": ObjectId(ingredient_id),
+                "user_id": current_user["uid"]
+            },
+            {"$set": updated.model_dump()}
         )
     except Exception:
         raise HTTPException(400, detail="Invalid ID format")
     if result.modified_count == 0:
         raise HTTPException(404, detail="Ingredient not found or not changed")
     updated_doc = await db.ingredients.find_one(
-        {"_id": ObjectId(ingredient_id)}
+         {
+           "_id": ObjectId(ingredient_id),
+           "user_id": current_user["uid"]
+         }
     )
     return format_ingredient(updated_doc)
 
 
 @router.delete("/{ingredient_id}", status_code=204)
-async def delete_ingredient(ingredient_id: str):
+async def delete_ingredient(
+    ingredient_id: str,
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    # Delete an ingredient if own by current user
     print(f"DELETE /ingredients/{ingredient_id}")
     try:
-        result = await db.ingredients.delete_one(
-            {"_id": ObjectId(ingredient_id)}
-        )
+        result = await db.ingredients.delete_one({
+            "_id": ObjectId(ingredient_id),
+            "user_id": current_user["uid"]
+        })
     except Exception:
         raise HTTPException(400, detail="Invalid ID format")
     if result.deleted_count == 0:

--- a/server/routes/recipes.py
+++ b/server/routes/recipes.py
@@ -7,86 +7,114 @@ from bson import ObjectId
 from datetime import datetime, timezone 
 from pydantic import BaseModel
 from db import get_db
-from models.recipe import RecipeCreate, RecipeOut, RecipeBase
+from dependencies import get_current_user   # ensures ingredients operations are scoped to users
+from models.recipe import RecipeCreate, RecipeOut, RecipeBase, format_recipe
 
 
 router = APIRouter(tags=["recipes"])
 
 # --- Recipe CRUD Endpoints ---
 
-@router.post("/", response_model=RecipeOut, status_code=201)
+
+@router.post("/", response_model=dict, status_code=201)
 async def create_recipe(
     recipe: RecipeCreate,
-    db: AsyncIOMotorDatabase = Depends(get_db)
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
 ):
-    # Create and save new recipe in mongoDB
+    # Create and save new recipe with timestamps and ownership
     doc = recipe.model_dump()
     doc["created_at"] = datetime.now(timezone.utc)
     doc["updated_at"] = datetime.now(timezone.utc)
-    # TODO: attach `doc["user_id"] = current_user.id` once auth is added
+    # Attach ownership of save recipes to user
+    doc["user_id"] = current_user["uid"]
     result = await db.recipes.insert_one(doc)
     new_doc = await db.recipes.find_one({"_id": result.inserted_id})
-    new_doc["_id"] = str(new_doc["_id"])
-    return new_doc
 
-@router.get("/", response_model=List[RecipeOut])
+    return format_recipe(new_doc)
+
+
+@router.get("/", response_model=List[dict])
 async def list_recipes(
-    db: AsyncIOMotorDatabase = Depends(get_db)
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
 ):
-    # List all recipes
-    # TODO: filter by user_id once scoped
-    docs = await db.recipes.find().to_list(length=None)
-    for doc in docs:
-        doc["_id"] = str(doc["_id"])
-    return docs
+    # List recipes owned by current user
+    docs = await db.recipes.find(
+        {"user_id": current_user["uid"]}
+    ).to_list(length=None)
+    # Convert each mongo doc to Pydantic model
+    return [format_recipe({**doc, "_id": doc["_id"]}) for doc in docs]
 
-@router.get("/{recipe_id}", response_model=RecipeOut)
+
+@router.get("/{recipe_id}", response_model=dict)
 async def get_recipe(
     recipe_id: str,
-    db: AsyncIOMotorDatabase = Depends(get_db)
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
 ):
-    # Retrieve a recipe by ID
-    doc = await db.recipes.find_one({"_id": ObjectId(recipe_id)})
+    # Retrieve a recipe by ID, ensuring user ownership
+    doc = await db.recipes.find_one({
+        "_id": ObjectId(recipe_id),
+        "user_id": current_user["uid"]
+    })
     if not doc:
         raise HTTPException(status_code=404, detail="Recipe not found")
-    # TODO: verify doc["user_id"] == current_user.id once auth is added
-    doc["_id"] = str(doc["_id"])
-    return doc
+    return format_recipe(doc)
 
-@router.put("/{recipe_id}", response_model=RecipeOut)
+
+# DISCUSS WITH TEAM - DO WE WANT TO ALLOW USERS TO MANUALLY EDIT RECIPES
+# OR ONLY SAVE, VIEW, AND DELETE?
+@router.put("/{recipe_id}", response_model=dict)
 async def update_recipe(
     recipe_id: str,
     recipe: RecipeCreate,
-    db: AsyncIOMotorDatabase = Depends(get_db)
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
 ):
-    # Update existing recipe. created_at stays static.
+    # Update existing recipe if owned by current user
     update_data = recipe.model_dump()
     update_data["updated_at"] = datetime.now(timezone.utc)
-    # TODO: ensure ownership filter when auth is in place
     result = await db.recipes.update_one(
-        {"_id": ObjectId(recipe_id)},
+        {
+            "_id": ObjectId(recipe_id),
+            "user_id": current_user["uid"]
+        },
         {"$set": update_data}
     )
     if result.matched_count == 0:
         raise HTTPException(status_code=404, detail="Recipe not found")
-    updated = await db.recipes.find_one({"_id": ObjectId(recipe_id)})
-    return updated
+    updated = await db.recipes.find_one({
+        "_id": ObjectId(recipe_id),
+        "user_id": current_user["uid"]
+    })
+    if not updated:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    updated["_id"] = str(updated["_id"])
+    return format_recipe(updated)
+
 
 @router.delete("/{recipe_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_recipe(
     recipe_id: str,
-    db: AsyncIOMotorDatabase = Depends(get_db)
+    db: AsyncIOMotorDatabase = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
 ):
-    # TODO: ensure ownership filter when auth is in place
-    result = await db.recipes.delete_one({"_id": ObjectId(recipe_id)})
+    # Ensures user ownership filter
+    result = await db.recipes.delete_one({
+        "_id": ObjectId(recipe_id),
+        "user_id": current_user["uid"]
+    })
     if result.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Recipe not found")
     return None
 
 # --- GPT Recipe Generation Endpoint ---
 
+
 class RecipeGenIn(BaseModel):
     ingredients: List[str]
+
 
 @router.post("/generate", response_model=RecipeBase)
 async def generate_recipe(


### PR DESCRIPTION
- Backend: Enforced user_id filter in FastAPI routes for ingredients & recipes.
- Frontend: Attached firebase token to every fetch.
- Frontend: Recipes Page - added functionality, per user
- Frontend: Recipes Page - delete is functional, edit/view button functional but pending implementation of individual recipes page, create is functional but pending implementation of GPT API
- Frontend: Recipes Page styling made consistent with pantry page. Generate Recipe Button added to call GPT API once implemented
- Slight refactoring of routes/ingredients.py to import from central db setup (db.py)
 
**------TESTING NOTES------**
1. Since Pantry and Recipes are now scoped to each user, http://127.0.0.1:8080/ingredients/ and http://127.0.0.1:8080/recipies/ will no longer be accessible from your browser.
2. Testing Pantry - You can test ingredients for different users from the UI. Login, navigate to pantry, add/edit/delete. Repeat for different user.
3. Testing Recipes - tricky until we have the GPT API implemented as that will create the recipes users can save. For now, you can manually create a recipe to see it in the user's Saved Recipes page:
      1. You need User's Token - there may be other ways but I found this the easiest:
                In Google Chrome:
                  Login as a user in HomeSpice
                  Open DevTools
                  Press ⌘ + Option + I
                  Or right-click on the page and choose Inspect
                  Switch to the Network tab
                  In the panel that pops up, click Network at the top.
                  Capture a request (click on pantry)
                  With the Network tab open, reload the page (⌘+R) so it records the requests.
                  Click on the request you want (e.g. GET /ingredients).
                  View the Authorization header
                  In the right-hand panel, under Headers ▶ Request Headers, look for the Authorization: Bearer … line.
                  Copy the long token string after Bearer.

      2. in Terminal:
                  curl -X POST http://localhost:8080/recipes \
                    -H "Authorization: Bearer <**ENTER USER'S TOKEN HERE**>" \
                    -H "Content-Type: application/json" \
                    -d '{
                      "title": "Test Recipe 1",
                      "description": "dish made from scraps",
                      "ingredients": ["1 Onion", "2 Garlic cloves"],
                      "steps": ["Chop ingredients", "Sauté until golden"],
                      "prep_time": 5,
                      "cook_time": 10,
                      "servings": 2,
                      "image_url": null
                  }'
        3. Delete button is functional. Edit/View button navigates to Individual Recipe Page which Tavner's working on.

OR

1. We can get on a call and test together before merging.

**------FOR DISCUSSION------**
Do we want users to be able to edit saved recipes or only view?

--------------------------------
Trello Cards:
https://trello.com/c/7zdSB5d2/42-create-individual-instances-when-logged-in - DONE, w/Alan
https://trello.com/c/juZidvgW/33-recipes-page-functionality - DONE
https://trello.com/c/7eBOsdlf/5-recipes-table - DONE
https://trello.com/c/f9YRRMM0/19-as-a-user-i-want-to-save-the-generated-recipes-i-like-so-that-i-can-easily-revisit-them-later-when-i-want-to-cook-them-again - IN PROGRESS w/Tavner